### PR TITLE
feat: cli `print`, `index`, & `report` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@ Creates an index mapping block CID to linked block CID for a CAR.
 
 Origin story: https://gist.github.com/alanshaw/876aafba676b13890398500b96f82d8e
 
+## Usage
+
+Here is a quick demo of what the linkdex CLI can do.
+
+```bash
+# Print indexes to stdout
+$ linkdex print thing-1.car thing-2.car
+bafybeiaalbzxtx6jxr5znrtjtxvdn76s7zxl7e4rw6mvrbjz6gahhnc54y --> bafybeietimcnchtujzibl4vqyvrcosagvfandacatiees4zed6updxdssi
+bafybeietimcnchtujzibl4vqyvrcosagvfandacatiees4zed6updxdssi --> bafkreic6ukg4v5hi7yt2qcebjpm2hkh34sejiiatr46wtiyntiwvlrskae
+bafybeietimcnchtujzibl4vqyvrcosagvfandacatiees4zed6updxdssi --> bafkreiabfvaraoupn66wrdcgy3l2bb7vwfqha2y4u3owtqw5hc75uhneyq
+
+# Writes indexes to file per CAR input
+$ linkdex index thing-1.car thing-2.car
+$ ls
+thing-1.car thing-1.car.linkdex thing-2.car thing-2.car.linkdex
+
+# Report the dag structure from the union of all the CARs
+$ linkdex report thing-1.car thing-2.car
+{"structure":"Complete","blockCount":21}
+
+# Exit with error if any block links to a CID that is not in the set of blocks.
+$ linkdex report thing-1.car --error-if-partial
+{"structure":"Partial","blockCount":10}
+Error: CAR(s) contain partial DAG
+$ echo $? # 1
+```
+
 ## Getting Stated
 
 Install the deps
@@ -11,10 +38,10 @@ Install the deps
 npm install
 ```
 
-pass it a car file, it writes the index in mermaid syntax to stdout  ✨🎷🐩
+pass it one or more car files, it writes the index in mermaid syntax to stdout  ✨🎷🐩
 
 ```console
-npm start ~/Code/olizilla/cardex-cli/lols.car
+./bin.js print --mermaid ~/Code/olizilla/cardex-cli/lols.car
 ```
 
 ```mermaid

--- a/bin.js
+++ b/bin.js
@@ -11,7 +11,7 @@ const cli = sade('linkdex')
 
 cli
   .version(pkg.version)
-  .example('report patial.car')
+  .example('report partial.car')
 
 cli.command('report <car>')
   .describe('Print a linkdex report for a car')

--- a/bin.js
+++ b/bin.js
@@ -1,9 +1,96 @@
 #!/usr/bin/env node
 
 import fs from 'fs'
-import { linkdex } from "./index.js"
+import sade from 'sade'
+import { linkdex, decodedBlocks } from './index.js'
+import { pipeline } from 'node:stream/promises'
 
-const input = process.argv[2]
-const inStream = fs.createReadStream(input)
+const pkg = JSON.parse(fs.readFileSync(new URL('./package.json', import.meta.url)))
 
-linkdex(inStream)
+const cli = sade('linkdex')
+
+cli
+  .version(pkg.version)
+  .example('report patial.car')
+
+cli.command('report <car>')
+  .describe('Print a linkdex report for a car')
+  .option('--error-if-partial')
+  .action(async (first, opts) => {
+    const cars = [first, ...opts._]
+    const index = new Map()
+    for (const car of cars) {
+      await pipeline(
+        fs.createReadStream(car),
+        async function * (source) {
+          for await (const {src, dest} of linkdex(source)){
+            let linkSet = index.get(src)
+            if (!linkSet) {
+              linkSet = new Set()
+              index.set(src, linkSet)
+            }
+            if (dest) {
+              linkSet.add(dest)
+            }
+          }
+        }
+      )
+    }
+    const res = report(index)
+    console.log(JSON.stringify(res))
+    if (opts['error-if-partial'] && res.structure === 'Partial') {
+      console.error('Error: CAR(s) contain partial DAG')
+      process.exit(1)
+    }
+  })
+
+function report (index) {
+  for (const [src, links] of index.entries()) {
+    for (const link of links) {
+      if (!index.has(link)) {
+        return { structure: 'Partial', blockCount: index.size }
+      }
+    }
+  }
+  return { structure: 'Complete', blockCount: index.size }
+}
+
+cli.command('print <car>')
+  .describe('Print index for a car')
+  .option('--mermaid')
+  .action(async (first, opts) => {
+    const cars = [first, ...opts._]
+    if(opts.mermaid) {
+      console.log('```mermaid')
+      console.log('graph LR')
+    }
+    for (const car of cars) {
+      const inStream = fs.createReadStream(car)
+      for await (const {src, dest} of linkdex(inStream)){
+        console.log(dest ? `${src} --> ${dest}` : src)
+      }
+    }
+    if(opts.mermaid) {
+      console.log('```')
+    }
+  })
+
+cli.command('index <car>')
+  .describe('Write out an index for a car to <car>.linkdex')
+  .action(async (first, opts) => {
+    const cars = [first, ...opts._]
+    for (const car of cars) {
+      const file = `${car}.linkdex`
+      await pipeline(
+        fs.createReadStream(car),
+        async function* (source) {
+          for await (const {src, dest} of linkdex(source)){
+            yield `${src} --> ${dest}\n`
+          }
+        },
+        fs.createWriteStream(file)
+      )
+    }
+  })
+
+cli.parse(process.argv)

--- a/index.js
+++ b/index.js
@@ -8,10 +8,15 @@ export async function * decodedBlocks (carStream) {
   }
 }
 
-export async function linkdex (inStream) {
-  for await (const block of decodedBlocks(inStream)) {
+export async function * linkdex (carStream) {
+  for await (const block of decodedBlocks(carStream)) {
+    let hasLinks = false
     for (const [path, targetCid] of block.links()) {
-      console.log(`${block.cid.toString()} --> ${targetCid.toString()}`)
+      hasLinks = true
+      yield { src: block.cid.toString(), dest: targetCid.toString() }
+    }
+    if (!hasLinks) {
+      yield { src: block.cid.toString() }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,11 @@
         "@ipld/dag-cbor": "^7.0.2",
         "@ipld/dag-json": "^8.0.10",
         "@ipld/dag-pb": "^2.1.17",
-        "multiformats": "^9.7.1"
+        "multiformats": "^9.7.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "linkdex": "bin.js"
       },
       "devDependencies": {
         "standard": "^17.0.0"
@@ -1808,6 +1812,14 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2314,6 +2326,17 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/semver": {
@@ -4029,6 +4052,11 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4373,6 +4401,14 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "requires": {
+        "mri": "^1.1.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@ipld/dag-cbor": "^7.0.2",
     "@ipld/dag-json": "^8.0.10",
     "@ipld/dag-pb": "^2.1.17",
-    "multiformats": "^9.7.1"
+    "multiformats": "^9.7.1",
+    "sade": "^1.8.1"
   },
   "devDependencies": {
     "standard": "^17.0.0"


### PR DESCRIPTION
Adds cli commands to print the linkdex, write it to file, or report on dag completeness.

Pass it one or more CARs. Here is a quick demo of what the `linkdex` CLI can do:

```bash
# Print indexes to stdout
$ linkdex print thing-1.car thing-2.car
bafybeiaalbzxtx6jxr5znrtjtxvdn76s7zxl7e4rw6mvrbjz6gahhnc54y --> bafybeietimcnchtujzibl4vqyvrcosagvfandacatiees4zed6updxdssi
bafybeietimcnchtujzibl4vqyvrcosagvfandacatiees4zed6updxdssi --> bafkreic6ukg4v5hi7yt2qcebjpm2hkh34sejiiatr46wtiyntiwvlrskae
bafybeietimcnchtujzibl4vqyvrcosagvfandacatiees4zed6updxdssi --> bafkreiabfvaraoupn66wrdcgy3l2bb7vwfqha2y4u3owtqw5hc75uhneyq

# Writes indexes to file per CAR input
$ linkdex index thing-1.car thing-2.car
$ ls
thing-1.car thing-1.car.linkdex thing-2.car thing-2.car.linkdex

# Report the dag structure from the union of all the CARs
$ linkdex report thing-1.car thing-2.car
{"structure":"Complete","blockCount":21}

# Exit with error if any block links to a CID that is not in the set of blocks.
$ linkdex report thing-1.car --error-if-partial
{"structure":"Partial","blockCount":10}
Error: CAR(s) contain partial DAG
$ echo $? # 1
```

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>