### PR TITLE
feat!: handle identity CIDs

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -25,6 +25,10 @@ const decoders = {
 export function maybeDecode ({ cid, bytes }, { codecs = decoders } = { codecs: decoders }) {
   const codec = codecs[cid.code]
   if (codec) {
+    if (cid.multihash.code === 0x0) {
+      // A CAR Block iterator would give us an empty bytes array, so use the cid bytes instead
+      return Block.createUnsafe({ cid, bytes: cid.multihash.digest, codec })
+    }
     return Block.createUnsafe({ cid, bytes, codec })
   }
 }

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ export class LinkIndexer {
    * @param {import('@ipld/car/api').Block} block
    * @param {object} [opts]
    * @param {import('./decode.js').BlockDecoders} [opts.codecs] - bring your own codecs
-   * @param {boolean} [opts.identityCidLink] - skip block index count if were processing an identity link cid
+   * @param {boolean} [opts.identityCidLink] - skip block index count if we're processing an identity link cid
    */
   decodeAndIndex ({ cid, bytes }, opts) {
     const block = maybeDecode({ cid, bytes }, opts)

--- a/index.js
+++ b/index.js
@@ -70,8 +70,8 @@ export class LinkIndexer {
   /**
    * Decode and index identity CID but don't count it as a block.
    * Where a link is an identity cid, The bytes are in the CID!
-   * We consider a CAR complete even if an identity CID does not appears only as a link,
-   * not a block entry, so we need to index it, but not count it as a block.
+   * We consider a CAR complete even if an identity CID appears only as a link, not a block entry.
+   * To make that work we index it, but don't count it as a block.
    * @param {import('multiformats/cid').CID} cid
    * @param {object} [opts]
    * @param {import('./decode.js').BlockDecoders} [opts.codecs] - bring your own codecs

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,8 +2,75 @@ import test from 'ava'
 import { encode } from 'multiformats/block'
 import * as pb from '@ipld/dag-pb'
 import * as json from '@ipld/dag-json'
+import { identity } from 'multiformats/hashes/identity'
 import { sha256 as hasher } from 'multiformats/hashes/sha2'
 import { LinkIndexer } from '../index.js'
+
+test('should index dag-json block with identity links (logically complete car)', async t => {
+  const id = await encode({ value: 'itsa me! mario!', codec: json, hasher: identity })
+  const block = await encode({ value: { Links: [id.cid] }, codec: json, hasher })
+  const linkIndexer = new LinkIndexer()
+  // logically complete CAR has a dag-json block that links to an identity CID that does not appear as a block entry in the car.
+  linkIndexer.decodeAndIndex({ cid: block.cid, bytes: block.bytes })
+  t.is(linkIndexer.isCompleteDag(), true)
+  t.is(linkIndexer.getDagStructureLabel(), 'Complete')
+  t.deepEqual(linkIndexer.report(), {
+    structure: 'Complete',
+    blocksIndexed: 1,
+    uniqueCids: 2,
+    undecodeable: 0
+  })
+})
+
+test('should index dag-json block and identity block (explicitly complete car)', async t => {
+  const id = await encode({ value: 'itsa me! mario!', codec: json, hasher: identity })
+  const block = await encode({ value: { Links: [id.cid] }, codec: json, hasher })
+  const linkIndexer = new LinkIndexer()
+  // logically complete CAR has a dag-json block that links to an identity CID that does not appear as a block entry in the car.
+  linkIndexer.decodeAndIndex({ cid: block.cid, bytes: block.bytes })
+  linkIndexer.decodeAndIndex({ cid: id.cid, bytes: new Uint8Array() })
+  t.is(linkIndexer.isCompleteDag(), true)
+  t.is(linkIndexer.getDagStructureLabel(), 'Complete')
+  t.deepEqual(linkIndexer.report(), {
+    structure: 'Complete',
+    blocksIndexed: 2,
+    uniqueCids: 2,
+    undecodeable: 0
+  })
+})
+
+test('should index identity cid blocks (explicitly complete car)', async t => {
+  const id = await encode({ value: 'itsa me! mario!', codec: json, hasher: identity })
+  const id2 = await encode({ value: { foo: id.cid }, codec: json, hasher: identity })
+  const linkIndexer = new LinkIndexer()
+  // very complete CAR has 2 identity links that are explicitly encoded as blocks in the CAR
+  linkIndexer.decodeAndIndex({ cid: id.cid, bytes: new Uint8Array() })
+  linkIndexer.decodeAndIndex({ cid: id2.cid, bytes: new Uint8Array() })
+  t.is(linkIndexer.isCompleteDag(), true)
+  t.is(linkIndexer.getDagStructureLabel(), 'Complete')
+  t.deepEqual(linkIndexer.report(), {
+    structure: 'Complete',
+    blocksIndexed: 2,
+    uniqueCids: 2,
+    undecodeable: 0
+  })
+})
+
+test('should index identity cids with dangling links (patitial via identity)', async t => {
+  const block = await encode({ value: pb.prepare({ Links: [] }), codec: pb, hasher })
+  const id = await encode({ value: { foo: block.cid }, codec: json, hasher: identity })
+  const linkIndexer = new LinkIndexer()
+  // we index the identity cid which links to a non-identity link that we don't index
+  linkIndexer.decodeAndIndex({ cid: id.cid, bytes: new Uint8Array() })
+  t.is(linkIndexer.isCompleteDag(), false)
+  t.is(linkIndexer.getDagStructureLabel(), 'Partial')
+  t.deepEqual(linkIndexer.report(), {
+    structure: 'Partial',
+    blocksIndexed: 1,
+    uniqueCids: 1,
+    undecodeable: 0
+  })
+})
 
 test('should index dag-pb with no links', async t => {
   const block = await encode({ value: pb.prepare({ Links: [] }), codec: pb, hasher })
@@ -14,8 +81,8 @@ test('should index dag-pb with no links', async t => {
   t.deepEqual(linkIndexer.report(), {
     structure: 'Complete',
     blocksIndexed: 1,
-    blocksUnique: 1,
-    blocksUndecodeable: 0
+    uniqueCids: 1,
+    undecodeable: 0
   })
 })
 
@@ -35,8 +102,8 @@ test('should index dag-pb with links for complete dag', async t => {
   t.deepEqual(linkIndexer.report(), {
     structure: 'Complete',
     blocksIndexed: 2,
-    blocksUnique: 2,
-    blocksUndecodeable: 0
+    uniqueCids: 2,
+    undecodeable: 0
   })
 })
 
@@ -49,8 +116,8 @@ test('should index dag-json with no links', async t => {
   t.deepEqual(linkIndexer.report(), {
     structure: 'Complete',
     blocksIndexed: 1,
-    blocksUnique: 1,
-    blocksUndecodeable: 0
+    uniqueCids: 1,
+    undecodeable: 0
   })
 })
 
@@ -70,8 +137,8 @@ test('should index dag-json with links for complete dag', async t => {
   t.deepEqual(linkIndexer.report(), {
     structure: 'Complete',
     blocksIndexed: 2,
-    blocksUnique: 2,
-    blocksUndecodeable: 0
+    uniqueCids: 2,
+    undecodeable: 0
   })
 })
 
@@ -85,7 +152,7 @@ test('should handle unknown codecs', async t => {
   t.deepEqual(linkIndexer.report(), {
     structure: 'Unknown',
     blocksIndexed: 0,
-    blocksUnique: 0,
-    blocksUndecodeable: 1
+    uniqueCids: 0,
+    undecodeable: 1
   })
 })


### PR DESCRIPTION
Identity CIDs use the `identity` multihash code `0x0`, to specify that the multihash digest is the data itself rather than a hash. 

Identity CIDs can be encountered anywhere you could find a regular `cid, bytes` pair:
- as an explicit entry in the CAR with its's bytes as a 0 length Uint8Array
- as a link target in the decoded bytes of the of a non-identity CID
- as a link target in an other identity CID (!)

I've chosen to define a given set of block to index as being a **Complete** DAG where a block links to Identity CIDs, even if those CIDs are not also part of the set of blocks to index, as we have all the data we need to complete the DAG. There is a tangentially related note about this concept in the indexing section of the CARv2 spec

> Indexes should not include identity hash CIDs unless the fully-indexed characteristic is set. It is assumed that any use of a CARv2 as a blockstore will return identity CID data immediately by extracting it from the CID, therefore there should be no need to provide indexing for such entries. However, when fully-indexed characteristic is set, the blockstore should persist blocks with identity CID into the CARv2 data payload and index them.
– https://ipld.io/specs/transport/car/carv2/#index-format

_note_ linkdex as currently implemented is not a spec compliant CARv2 index, and it is not yet aiming to be. This note is just useful context to see another example of handling identity CIDs.

I've also updated the linkdex report output to more accurately reflect what is being counted:
- `blocksIndexed` is the count of the number of blocks that the LinkIndexer was asked to index... This does not include identity CIDs that only appear as link targets. It does in include identity CIDs that appear as explicit block entires. If the caller asks us to index it, then it's counted as a block. 
- `uniqueCids` is the count of **all** unique CIDs encountered, including both explicitly indexed identity CIDs and implicitly indexed Identity CIDs found as link targets.
- `undecodable` is the count of undecodable items, including blocks and identity CIDs... DAG completeness is unknowable if we encounter an undecodable item of either sort.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>