### PR TITLE
feat!: pass custom ipld codecs to constructor

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -4,26 +4,25 @@ import * as json from '@ipld/dag-json'
 import * as cbor from '@ipld/dag-cbor'
 import * as pb from '@ipld/dag-pb'
 
-/** @typedef {Record<number, import('multiformats/block').BlockDecoder<?, ?>>} BlockDecoders */
+/**
+ * @template {number} Code
+ * @template T
+ * @typedef {Map<Code, import('multiformats/block').BlockDecoder<Code, T>>} BlockDecoderMap
+ */
 
-/** @type BlockDecoders */
-const decoders = {
-  [pb.code]: pb,
-  [raw.code]: raw,
-  [cbor.code]: cbor,
-  [json.code]: json
-}
+/** @type BlockDecoderMap<?, ?> */
+export const decoders = new Map([pb, raw, cbor, json].map(c => [c.code, c]))
 
 /**
  * Decode a CAR Block (bytes) into a multiformats Block.
  * Decoding allows us to find out if that block links to any others by CID.
  * @param {import('@ipld/car/api').Block} block
  * @param {object} opts
- * @param {BlockDecoders} [opts.codecs]
+ * @param {BlockDecoderMap<?, ?>} [opts.codecs]
  * @returns {Block.Block<?> | undefined}
  */
 export function maybeDecode ({ cid, bytes }, { codecs = decoders } = { codecs: decoders }) {
-  const codec = codecs[cid.code]
+  const codec = codecs.get(cid.code)
   if (codec) {
     if (cid.multihash.code === 0x0) {
       // A CAR Block iterator would give us an empty bytes array, so use the cid bytes instead


### PR DESCRIPTION
Allow users to pass custom IPLD codecs to the constructor rather than having to pass them in on every call.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>