### PR TITLE
feat: hash verification

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -1,30 +1,17 @@
 import * as Block from 'multiformats/block'
 import * as raw from 'multiformats/codecs/raw'
-import { sha256 } from 'multiformats/hashes/sha2'
-import { identity } from 'multiformats/hashes/identity'
-import { equals } from 'multiformats/bytes'
 import * as json from '@ipld/dag-json'
 import * as cbor from '@ipld/dag-cbor'
 import * as pb from '@ipld/dag-pb'
 
-/**
- * @typedef {Record<number, import('multiformats/codecs/interface').BlockDecoder<?, ?>>} BlockDecoders
- * @typedef {Record<number, import('multiformats/hashes/interface').MultihashHasher<any>>} MultihashHashers
- * @typedef {'pass'|'fail'|'unknown'} HashVerificationResult
- */
+/** @typedef {Record<number, import('multiformats/codecs/interface').BlockDecoder<?, ?>>} BlockDecoders */
 
-/** @type {BlockDecoders} */
+/** @type BlockDecoders */
 const decoders = {
   [pb.code]: pb,
   [raw.code]: raw,
   [cbor.code]: cbor,
   [json.code]: json
-}
-
-/** @type {MultihashHashers} */
-const multihashHashers = {
-  [identity.code]: identity,
-  [sha256.code]: sha256
 }
 
 /**
@@ -43,23 +30,4 @@ export function maybeDecode ({ cid, bytes }, { codecs = decoders } = { codecs: d
     }
     return Block.createUnsafe({ cid, bytes, codec })
   }
-}
-
-/**
- * Verify block bytes hash to the expected CID.
- * @param {import('@ipld/car/api').Block} block
- * @param {object} [opts]
- * @param {MultihashHashers} [opts.hashers]
- * @returns {HashVerificationResult|Promise<HashVerificationResult>}
- */
-export function verifyHash ({ cid, bytes }, opts = {}) {
-  const hashers = opts.hashers || multihashHashers
-  const hasher = hashers[cid.multihash.code]
-  if (!hasher) return 'unknown'
-  const result = hasher.digest(bytes)
-  /** @param {import('multiformats/hashes/interface').MultihashDigest} h */
-  const compareDigests = h => equals(cid.multihash.bytes, h.bytes) ? 'pass' : 'fail'
-  return result instanceof Promise
-    ? result.then(compareDigests)
-    : compareDigests(result)
 }

--- a/decode.js
+++ b/decode.js
@@ -1,17 +1,30 @@
 import * as Block from 'multiformats/block'
 import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { identity } from 'multiformats/hashes/identity'
+import { equals } from 'multiformats/bytes'
 import * as json from '@ipld/dag-json'
 import * as cbor from '@ipld/dag-cbor'
 import * as pb from '@ipld/dag-pb'
 
-/** @typedef {Record<number, import('multiformats/block').BlockDecoder<?, ?>>} BlockDecoders */
+/**
+ * @typedef {Record<number, import('multiformats/codecs/interface').BlockDecoder<?, ?>>} BlockDecoders
+ * @typedef {Record<number, import('multiformats/hashes/interface').MultihashHasher<any>>} MultihashHashers
+ * @typedef {'pass'|'fail'|'unknown'} HashVerificationResult
+ */
 
-/** @type BlockDecoders */
+/** @type {BlockDecoders} */
 const decoders = {
   [pb.code]: pb,
   [raw.code]: raw,
   [cbor.code]: cbor,
   [json.code]: json
+}
+
+/** @type {MultihashHashers} */
+const multihashHashers = {
+  [identity.code]: identity,
+  [sha256.code]: sha256
 }
 
 /**
@@ -20,7 +33,6 @@ const decoders = {
  * @param {import('@ipld/car/api').Block} block
  * @param {object} opts
  * @param {BlockDecoders} [opts.codecs]
- * @returns {Block.Block<?> | undefined}
  */
 export function maybeDecode ({ cid, bytes }, { codecs = decoders } = { codecs: decoders }) {
   const codec = codecs[cid.code]
@@ -31,4 +43,23 @@ export function maybeDecode ({ cid, bytes }, { codecs = decoders } = { codecs: d
     }
     return Block.createUnsafe({ cid, bytes, codec })
   }
+}
+
+/**
+ * Verify block bytes hash to the expected CID.
+ * @param {import('@ipld/car/api').Block} block
+ * @param {object} [opts]
+ * @param {MultihashHashers} [opts.hashers]
+ * @returns {HashVerificationResult|Promise<HashVerificationResult>}
+ */
+export function verifyHash ({ cid, bytes }, opts = {}) {
+  const hashers = opts.hashers || multihashHashers
+  const hasher = hashers[cid.multihash.code]
+  if (!hasher) return 'unknown'
+  const result = hasher.digest(bytes)
+  /** @param {import('multiformats/hashes/interface').MultihashDigest} h */
+  const compareDigests = h => equals(cid.multihash.bytes, h.bytes) ? 'pass' : 'fail'
+  return result instanceof Promise
+    ? result.then(compareDigests)
+    : compareDigests(result)
 }

--- a/hashing-indexer.js
+++ b/hashing-indexer.js
@@ -1,0 +1,82 @@
+import { validateBlock, UnsupportedHashError, HashMismatchError } from '@web3-storage/car-block-validator'
+import { LinkIndexer } from './index.js'
+
+/**
+ * @typedef {object} HashReport
+ * @property {number} hashPassed How many CIDs were verified as matching block bytes.
+ * @property {number} hashFailed How many CIDs failed verification that they matched block bytes.
+ * @property {number} hashUnknown How many CIDs could not be verified because the hashing function was unknown.
+*/
+
+/**
+ * A link indexer that also verifies that block bytes hash to their reported CID.
+ */
+export class HashingLinkIndexer extends LinkIndexer {
+  constructor () {
+    super()
+    this.hashPassed = 0
+    this.hashFailed = 0
+    this.hashUnknown = 0
+  }
+
+  /**
+   * Hash the block bytes to verify the CID matches, decode the block and index
+   * any CIDs the block links to.
+   * @param {import('@ipld/car/api').Block} block
+   * @param {object} [opts]
+   * @param {import('./decode').BlockDecoders} [opts.codecs] - bring your own codecs
+   */
+  decodeAndIndex ({ cid, bytes }, opts) {
+    const handleValidateSuccess = () => {
+      this.hashPassed++
+      return super.decodeAndIndex({ cid, bytes }, opts)
+    }
+    /** @param {Error} err */
+    const handleValidateFailure = err => {
+      if (err instanceof UnsupportedHashError) {
+        this.hashUnknown++
+      } else if (err instanceof HashMismatchError) {
+        this.hashFailed++
+      } else {
+        throw err
+      }
+      return super.decodeAndIndex({ cid, bytes }, opts)
+    }
+    try {
+      // @ts-expect-error
+      const result = validateBlock({ cid, bytes })
+      if (result instanceof Promise) {
+        return result.then(handleValidateSuccess, handleValidateFailure)
+      }
+      return handleValidateSuccess()
+    } catch (/** @type {any} */ err) {
+      return handleValidateFailure(err)
+    }
+  }
+
+  isCompleteDag () {
+    if (this.hashFailed > 0) {
+      throw new Error('DAG completeness unknown! Some blocks failed hash verification')
+    }
+    if (this.hashUnknown > 0) {
+      throw new Error('DAG completeness unknown! Some CIDs use unknown hash functions')
+    }
+    return super.isCompleteDag()
+  }
+
+  getDagStructureLabel () {
+    if (this.hashFailed > 0 || this.hashUnknown > 0) {
+      return 'Unknown'
+    }
+    return super.getDagStructureLabel()
+  }
+
+  /** @returns {import('./index').Report & HashReport} */
+  report () {
+    return Object.assign(super.report(), {
+      hashPassed: this.hashPassed,
+      hashFailed: this.hashFailed,
+      hashUnknown: this.hashUnknown
+    })
+  }
+}

--- a/hashing-indexer.js
+++ b/hashing-indexer.js
@@ -43,7 +43,7 @@ export class HashingLinkIndexer extends LinkIndexer {
       return super.decodeAndIndex({ cid, bytes }, opts)
     }
     try {
-      // @ts-expect-error
+      // @ts-expect-error CID type mismatch because old multiformats
       const result = validateBlock({ cid, bytes })
       if (result instanceof Promise) {
         return result.then(handleValidateSuccess, handleValidateFailure)

--- a/index.js
+++ b/index.js
@@ -90,7 +90,10 @@ export class LinkIndexer {
    * @param {import('./decode').BlockDecoders} [opts.codecs] - bring your own codecs
    */
   hashAndIndex ({ cid, bytes }, opts) {
-    const handleValidateSuccess = () => this.decodeAndIndex({ cid, bytes }, opts)
+    const handleValidateSuccess = () => {
+      this.hashPassed++
+      return this.decodeAndIndex({ cid, bytes }, opts)
+    }
     /** @param {Error} err */
     const handleValidateFailure = err => {
       if (err instanceof UnsupportedHashError) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@multiformats/blake2": "^1.0.13",
+        "@web3-storage/car-block-validator": "^1.2.0",
         "multiformats": "^11.0.2",
         "sade": "^1.8.1"
       },
@@ -144,6 +145,34 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
+    "node_modules/@multiformats/murmur3": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
+      "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
+      "dependencies": {
+        "multiformats": "^9.5.4",
+        "murmurhash3js-revisited": "^3.0.0"
+      }
+    },
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/@multiformats/sha3": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.16.tgz",
+      "integrity": "sha512-6KVY8f292kA9BxZJyrAjtIvqXCxs3JRvA5GOMM2IAVxYRMDDk5ldlOR6HMSTv+Q9LNgJ0jx4Y9Y6z7KSHLO1tA==",
+      "dependencies": {
+        "js-sha3": "^0.8.0",
+        "multiformats": "^9.5.4"
+      }
+    },
+    "node_modules/@multiformats/sha3/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -190,6 +219,23 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
       "integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==",
       "dev": true
+    },
+    "node_modules/@web3-storage/car-block-validator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.0.tgz",
+      "integrity": "sha512-KKQ/M5WtpH/JlkX+bQYKzdG4azmSF495T7vpewje2xh7MBh1d94/BLblxCcLM/larWvXDxOkbAyTTdlECAAuUw==",
+      "dependencies": {
+        "@multiformats/blake2": "^1.0.13",
+        "@multiformats/murmur3": "^1.1.3",
+        "@multiformats/sha3": "^2.0.15",
+        "multiformats": "9.9.0",
+        "uint8arrays": "^3.1.1"
+      }
+    },
+    "node_modules/@web3-storage/car-block-validator/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -2540,6 +2586,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -2839,6 +2890,14 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/murmurhash3js-revisited": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/natural-compare": {
@@ -4008,6 +4067,19 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -4344,6 +4416,38 @@
         }
       }
     },
+    "@multiformats/murmur3": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
+      "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
+      "requires": {
+        "multiformats": "^9.5.4",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
+      }
+    },
+    "@multiformats/sha3": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.16.tgz",
+      "integrity": "sha512-6KVY8f292kA9BxZJyrAjtIvqXCxs3JRvA5GOMM2IAVxYRMDDk5ldlOR6HMSTv+Q9LNgJ0jx4Y9Y6z7KSHLO1tA==",
+      "requires": {
+        "js-sha3": "^0.8.0",
+        "multiformats": "^9.5.4"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4381,6 +4485,25 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
       "integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==",
       "dev": true
+    },
+    "@web3-storage/car-block-validator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.0.tgz",
+      "integrity": "sha512-KKQ/M5WtpH/JlkX+bQYKzdG4azmSF495T7vpewje2xh7MBh1d94/BLblxCcLM/larWvXDxOkbAyTTdlECAAuUw==",
+      "requires": {
+        "@multiformats/blake2": "^1.0.13",
+        "@multiformats/murmur3": "^1.1.3",
+        "@multiformats/sha3": "^2.0.15",
+        "multiformats": "9.9.0",
+        "uint8arrays": "^3.1.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
+      }
     },
     "acorn": {
       "version": "8.8.0",
@@ -6051,6 +6174,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -6276,6 +6404,11 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+    },
+    "murmurhash3js-revisited": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -7060,6 +7193,21 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
       "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true
+    },
+    "uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "requires": {
+        "multiformats": "^9.4.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
+      }
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
       "version": "2.0.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@ipld/car": "^4.1.4",
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-json": "^8.0.10",
-        "@ipld/dag-pb": "^2.1.17",
-        "multiformats": "^9.7.1",
+        "@ipld/car": "^5.1.1",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.1",
+        "@ipld/dag-pb": "^4.0.2",
+        "@multiformats/blake2": "^1.0.13",
+        "multiformats": "^11.0.2",
         "sade": "^1.8.1"
       },
       "bin": {
@@ -77,41 +78,71 @@
       "dev": true
     },
     "node_modules/@ipld/car": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-4.1.4.tgz",
-      "integrity": "sha512-qJs1DoHklninRmwVfyQrp9+wDLIo4JAhkXBx6XSA9fsvAELA0WJOc2bNL6G2zg0MQQPrr5XEJd72ft1apWwMng==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.1.tgz",
+      "integrity": "sha512-HoFTUqUJL9cPGhC9qRmHCvamfIsj1JllQSQ/Xu9/KN/VNJp8To9Ms4qiZPEMOwcrNFclfYqrahjGYbf4KL/d9A==",
       "dependencies": {
-        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
-        "multiformats": "^9.5.4",
+        "multiformats": "^11.0.0",
         "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ipld/dag-cbor": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.2.tgz",
-      "integrity": "sha512-V9EhJVWXqzjjRs0kiZfUXOaq8y6R2C4AAmfGoMeszqGOBgfACr5tFAgAwZY0e8z/OpmJWpCrZhzPRTZV0c/gjA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
+      "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
       "dependencies": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ipld/dag-json": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.10.tgz",
-      "integrity": "sha512-fny24vxVtgAv7aKmAikZq86kikp56knZL/77eyXUsrgGRGtkx9D1awemKbhIVw/7S5nBbP43m/AZwxNPVpP5eg==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
+      "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
       "dependencies": {
-        "cborg": "^1.5.4",
-        "multiformats": "^9.5.4"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ipld/dag-pb": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.17.tgz",
-      "integrity": "sha512-AmzOdmdv5hT8iGsrbpzm5R0Fvk7DEbtwcglG2gJLvW9q3zwb+E681hY4EwEELypM1Rfnp/JDA9dGqYcpEi/iAg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+      "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
       "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/blake2": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
+      "integrity": "sha512-T1Kzya0wjj85CaVeRSpJ858EnSvW1pw94GSitxYf84VsNdv5XYbJ6QG8y26Ft1bVALzrUCmqkQrR53QHSyu6RA==",
+      "dependencies": {
+        "blakejs": "^1.1.1",
         "multiformats": "^9.5.4"
       }
+    },
+    "node_modules/@multiformats/blake2/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -651,6 +682,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
     "node_modules/blueimp-md5": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
@@ -723,9 +759,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.4.tgz",
-      "integrity": "sha512-ltobKo17xKYJolhg8UxQhvzcqXhjtUnovwe9Xx59Izo32gLwozGoJs/efp+8dZ5+zu9pNJYnHtmp6iJnDUapww==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.1.tgz",
+      "integrity": "sha512-et6Qm8MOUY2kCWa5GKk2MlBVoPjHv0hQBmlzI/Z7+5V3VJCeIkGehIB3vWknNsm2kOkAIs6wEKJFJo8luWQQ/w==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -2797,9 +2833,13 @@
       "dev": true
     },
     "node_modules/multiformats": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.7.1.tgz",
-      "integrity": "sha512-TaVmGEBt0fhxiNJMGphBfB+oGvUxFs8KgGvgl8d3C+GWtrFcvXdJ2196eg+dYhmSFClmgFfSfJEklo+SZzdNuw=="
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4252,40 +4292,56 @@
       "dev": true
     },
     "@ipld/car": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-4.1.4.tgz",
-      "integrity": "sha512-qJs1DoHklninRmwVfyQrp9+wDLIo4JAhkXBx6XSA9fsvAELA0WJOc2bNL6G2zg0MQQPrr5XEJd72ft1apWwMng==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.1.tgz",
+      "integrity": "sha512-HoFTUqUJL9cPGhC9qRmHCvamfIsj1JllQSQ/Xu9/KN/VNJp8To9Ms4qiZPEMOwcrNFclfYqrahjGYbf4KL/d9A==",
       "requires": {
-        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
-        "multiformats": "^9.5.4",
+        "multiformats": "^11.0.0",
         "varint": "^6.0.0"
       }
     },
     "@ipld/dag-cbor": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.2.tgz",
-      "integrity": "sha512-V9EhJVWXqzjjRs0kiZfUXOaq8y6R2C4AAmfGoMeszqGOBgfACr5tFAgAwZY0e8z/OpmJWpCrZhzPRTZV0c/gjA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
+      "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
       "requires": {
-        "cborg": "^1.6.0",
-        "multiformats": "^9.5.4"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
       }
     },
     "@ipld/dag-json": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.10.tgz",
-      "integrity": "sha512-fny24vxVtgAv7aKmAikZq86kikp56knZL/77eyXUsrgGRGtkx9D1awemKbhIVw/7S5nBbP43m/AZwxNPVpP5eg==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.0.1.tgz",
+      "integrity": "sha512-XE1Eqw3eNVrSfOhtqCM/gwCxEgYFBzkDlkwhEeMmMvhd0rLBfSyVzXbahZSlv97tiTPEIx5rt41gcFAda3W8zg==",
       "requires": {
-        "cborg": "^1.5.4",
-        "multiformats": "^9.5.4"
+        "cborg": "^1.10.0",
+        "multiformats": "^11.0.0"
       }
     },
     "@ipld/dag-pb": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.17.tgz",
-      "integrity": "sha512-AmzOdmdv5hT8iGsrbpzm5R0Fvk7DEbtwcglG2gJLvW9q3zwb+E681hY4EwEELypM1Rfnp/JDA9dGqYcpEi/iAg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+      "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
       "requires": {
+        "multiformats": "^11.0.0"
+      }
+    },
+    "@multiformats/blake2": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
+      "integrity": "sha512-T1Kzya0wjj85CaVeRSpJ858EnSvW1pw94GSitxYf84VsNdv5XYbJ6QG8y26Ft1bVALzrUCmqkQrR53QHSyu6RA==",
+      "requires": {
+        "blakejs": "^1.1.1",
         "multiformats": "^9.5.4"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -4651,6 +4707,11 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
     "blueimp-md5": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
@@ -4711,9 +4772,9 @@
       }
     },
     "cborg": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.4.tgz",
-      "integrity": "sha512-ltobKo17xKYJolhg8UxQhvzcqXhjtUnovwe9Xx59Izo32gLwozGoJs/efp+8dZ5+zu9pNJYnHtmp6iJnDUapww=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.1.tgz",
+      "integrity": "sha512-et6Qm8MOUY2kCWa5GKk2MlBVoPjHv0hQBmlzI/Z7+5V3VJCeIkGehIB3vWknNsm2kOkAIs6wEKJFJo8luWQQ/w=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -6212,9 +6273,9 @@
       "dev": true
     },
     "multiformats": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.7.1.tgz",
-      "integrity": "sha512-TaVmGEBt0fhxiNJMGphBfB+oGvUxFs8KgGvgl8d3C+GWtrFcvXdJ2196eg+dYhmSFClmgFfSfJEklo+SZzdNuw=="
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
-        "@multiformats/blake2": "^1.0.13",
         "@web3-storage/car-block-validator": "^1.2.0",
         "multiformats": "^11.0.2",
         "sade": "^1.8.1"
@@ -22,6 +21,7 @@
         "linkdex": "bin.js"
       },
       "devDependencies": {
+        "@multiformats/blake2": "^1.0.13",
         "@types/node": "^18.7.14",
         "ava": "^4.3.3",
         "standard": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@multiformats/blake2": "^1.0.13",
+    "@web3-storage/car-block-validator": "^1.2.0",
     "multiformats": "^11.0.2",
     "sade": "^1.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
     "make-cars": "dd if=/dev/urandom of=./random-100mib-file bs=1024 count=102400 && npx ipfs-car --pack random-100mib-file && npx carbites-cli split random-100mib-file.car --size 10MB --strategy treewalk"
   },
   "dependencies": {
-    "@ipld/car": "^4.1.4",
-    "@ipld/dag-cbor": "^7.0.2",
-    "@ipld/dag-json": "^8.0.10",
-    "@ipld/dag-pb": "^2.1.17",
-    "multiformats": "^9.7.1",
+    "@ipld/car": "^5.1.1",
+    "@ipld/dag-cbor": "^9.0.0",
+    "@ipld/dag-json": "^10.0.1",
+    "@ipld/dag-pb": "^4.0.2",
+    "@multiformats/blake2": "^1.0.13",
+    "multiformats": "^11.0.2",
     "sade": "^1.8.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "@ipld/dag-cbor": "^9.0.0",
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
-    "@multiformats/blake2": "^1.0.13",
     "@web3-storage/car-block-validator": "^1.2.0",
     "multiformats": "^11.0.2",
     "sade": "^1.8.1"
   },
   "devDependencies": {
+    "@multiformats/blake2": "^1.0.13",
     "@types/node": "^18.7.14",
     "ava": "^4.3.3",
     "standard": "^17.0.0",

--- a/test/hashing-indexer.test.js
+++ b/test/hashing-indexer.test.js
@@ -1,0 +1,66 @@
+import test from 'ava'
+import { encode } from 'multiformats/block'
+import * as json from '@ipld/dag-json'
+import { sha256 as hasher } from 'multiformats/hashes/sha2'
+import { blake2b512 } from '@multiformats/blake2/blake2b'
+import { HashingLinkIndexer } from '../hashing-indexer.js'
+
+test('should do hash verification', async t => {
+  const block = await encode({ value: { pass: 'block' }, codec: json, hasher })
+
+  const linkIndexer = new HashingLinkIndexer()
+  await linkIndexer.decodeAndIndex(block)
+
+  t.is(linkIndexer.getDagStructureLabel(), 'Complete')
+  t.is(linkIndexer.isCompleteDag(), true)
+  t.deepEqual(linkIndexer.report(), {
+    structure: 'Complete',
+    blocksIndexed: 1,
+    uniqueCids: 1,
+    undecodeable: 0,
+    hashPassed: 1,
+    hashFailed: 0,
+    hashUnknown: 0
+  })
+})
+
+test('should handle failed hash verification', async t => {
+  const block = {
+    cid: (await encode({ value: 'xxx', codec: json, hasher })).cid,
+    bytes: (await encode({ value: 'yyy', codec: json, hasher })).bytes
+  }
+
+  const linkIndexer = new HashingLinkIndexer()
+  await linkIndexer.decodeAndIndex(block)
+
+  t.is(linkIndexer.getDagStructureLabel(), 'Unknown')
+  t.throws(() => linkIndexer.isCompleteDag(), { message: /blocks failed hash verification/ })
+  t.deepEqual(linkIndexer.report(), {
+    structure: 'Unknown',
+    blocksIndexed: 1,
+    uniqueCids: 1,
+    undecodeable: 0,
+    hashPassed: 0,
+    hashFailed: 1,
+    hashUnknown: 0
+  })
+})
+
+test('should handle unknown hash functions', async t => {
+  const block = await encode({ value: 'yyy', codec: json, hasher: blake2b512 })
+
+  const linkIndexer = new HashingLinkIndexer()
+  await linkIndexer.decodeAndIndex(block)
+
+  t.is(linkIndexer.getDagStructureLabel(), 'Unknown')
+  t.throws(() => linkIndexer.isCompleteDag(), { message: /CIDs use unknown hash functions/ })
+  t.deepEqual(linkIndexer.report(), {
+    structure: 'Unknown',
+    blocksIndexed: 1,
+    uniqueCids: 1,
+    undecodeable: 0,
+    hashPassed: 0,
+    hashFailed: 0,
+    hashUnknown: 1
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ import * as pb from '@ipld/dag-pb'
 import * as json from '@ipld/dag-json'
 import { identity } from 'multiformats/hashes/identity'
 import { sha256 as hasher } from 'multiformats/hashes/sha2'
-import { blake2b256 } from '@multiformats/blake2/blake2b'
+import { blake2b512 } from '@multiformats/blake2/blake2b'
 import { LinkIndexer } from '../index.js'
 
 test('should index dag-json block with identity links (logically complete car)', async t => {
@@ -227,7 +227,7 @@ test('should handle failed hash verification', async t => {
 })
 
 test('should handle unknown hash functions', async t => {
-  const block = await encode({ value: 'yyy', codec: json, hasher: blake2b256 })
+  const block = await encode({ value: 'yyy', codec: json, hasher: blake2b512 })
 
   const linkIndexer = new LinkIndexer()
   await linkIndexer.hashAndIndex(block)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,6 @@ import * as pb from '@ipld/dag-pb'
 import * as json from '@ipld/dag-json'
 import { identity } from 'multiformats/hashes/identity'
 import { sha256 as hasher } from 'multiformats/hashes/sha2'
-import { blake2b512 } from '@multiformats/blake2/blake2b'
 import { LinkIndexer } from '../index.js'
 
 test('should index dag-json block with identity links (logically complete car)', async t => {
@@ -19,10 +18,7 @@ test('should index dag-json block with identity links (logically complete car)',
     structure: 'Complete',
     blocksIndexed: 1,
     uniqueCids: 2,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
+    undecodeable: 0
   })
 })
 
@@ -39,10 +35,7 @@ test('should index dag-json block and identity block (explicitly complete car)',
     structure: 'Complete',
     blocksIndexed: 2,
     uniqueCids: 2,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
+    undecodeable: 0
   })
 })
 
@@ -59,10 +52,7 @@ test('should index identity cid blocks (explicitly complete car)', async t => {
     structure: 'Complete',
     blocksIndexed: 2,
     uniqueCids: 2,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
+    undecodeable: 0
   })
 })
 
@@ -78,10 +68,7 @@ test('should index identity cids with dangling links (patitial via identity)', a
     structure: 'Partial',
     blocksIndexed: 1,
     uniqueCids: 1,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
+    undecodeable: 0
   })
 })
 
@@ -95,10 +82,7 @@ test('should index dag-pb with no links', async t => {
     structure: 'Complete',
     blocksIndexed: 1,
     uniqueCids: 1,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
+    undecodeable: 0
   })
 })
 
@@ -119,10 +103,7 @@ test('should index dag-pb with links for complete dag', async t => {
     structure: 'Complete',
     blocksIndexed: 2,
     uniqueCids: 2,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
+    undecodeable: 0
   })
 })
 
@@ -136,10 +117,7 @@ test('should index dag-json with no links', async t => {
     structure: 'Complete',
     blocksIndexed: 1,
     uniqueCids: 1,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
+    undecodeable: 0
   })
 })
 
@@ -160,10 +138,7 @@ test('should index dag-json with links for complete dag', async t => {
     structure: 'Complete',
     blocksIndexed: 2,
     uniqueCids: 2,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
+    undecodeable: 0
   })
 })
 
@@ -178,69 +153,6 @@ test('should handle unknown codecs', async t => {
     structure: 'Unknown',
     blocksIndexed: 0,
     uniqueCids: 0,
-    undecodeable: 1,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 0
-  })
-})
-
-test('should do hash verification', async t => {
-  const block = await encode({ value: { pass: 'block' }, codec: json, hasher })
-
-  const linkIndexer = new LinkIndexer()
-  await linkIndexer.hashAndIndex(block)
-
-  t.is(linkIndexer.getDagStructureLabel(), 'Complete')
-  t.is(linkIndexer.isCompleteDag(), true)
-  t.deepEqual(linkIndexer.report(), {
-    structure: 'Complete',
-    blocksIndexed: 1,
-    uniqueCids: 1,
-    undecodeable: 0,
-    hashPassed: 1,
-    hashFailed: 0,
-    hashUnknown: 0
-  })
-})
-
-test('should handle failed hash verification', async t => {
-  const block = {
-    cid: (await encode({ value: 'xxx', codec: json, hasher })).cid,
-    bytes: (await encode({ value: 'yyy', codec: json, hasher })).bytes
-  }
-
-  const linkIndexer = new LinkIndexer()
-  await linkIndexer.hashAndIndex(block)
-
-  t.is(linkIndexer.getDagStructureLabel(), 'Unknown')
-  t.throws(() => linkIndexer.isCompleteDag(), { message: /blocks failed hash verification/ })
-  t.deepEqual(linkIndexer.report(), {
-    structure: 'Unknown',
-    blocksIndexed: 1,
-    uniqueCids: 1,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 1,
-    hashUnknown: 0
-  })
-})
-
-test('should handle unknown hash functions', async t => {
-  const block = await encode({ value: 'yyy', codec: json, hasher: blake2b512 })
-
-  const linkIndexer = new LinkIndexer()
-  await linkIndexer.hashAndIndex(block)
-
-  t.is(linkIndexer.getDagStructureLabel(), 'Unknown')
-  t.throws(() => linkIndexer.isCompleteDag(), { message: /CIDs use unknown hash functions/ })
-  t.deepEqual(linkIndexer.report(), {
-    structure: 'Unknown',
-    blocksIndexed: 1,
-    uniqueCids: 1,
-    undecodeable: 0,
-    hashPassed: 0,
-    hashFailed: 0,
-    hashUnknown: 1
+    undecodeable: 1
   })
 })


### PR DESCRIPTION
Adds hash verification to `LinkIndexer`. To verify hashes in addition to indexing links use the `HashingLinkIndexer` class.

The linkdex report generated by `HashingLinkIndexer` contains 3 additional fields:

```ts
hashPassed: number // How many CIDs were verified as matching block bytes
hashFailed: number // How many CIDs failed verification that they matched block bytes
hashUnknown: number // How many CIDs could not be verified because the hash was unknown
```

DAG structure will be `Unknown` and `isCompleteDag` will throw if `hashFailed` or `hashUnknown` are positive.