### PR TITLE
feat: memory efficient reporter

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,7 +3,7 @@
 import * as fs from 'fs'
 import sade from 'sade'
 import { linkdex } from './index.js'
-import { HashingLinkIndexer } from './hashing-indexer.js'
+import { Reporter } from './reporter.js'
 import { CarBlockIterator } from '@ipld/car/iterator'
 import { pipeline } from 'node:stream/promises'
 
@@ -19,7 +19,7 @@ cli.command('report <car>', 'Print a linkdex report for a car', { default: true 
   .option('--error-if-partial')
   .action(async (first, opts) => {
     const cars = [first, ...opts._]
-    const index = new HashingLinkIndexer()
+    const index = new Reporter()
     for (const car of cars) {
       const carStream = fs.createReadStream(car)
       const carBlocks = await CarBlockIterator.fromIterable(carStream)

--- a/reporter.js
+++ b/reporter.js
@@ -1,0 +1,67 @@
+import { HashingLinkIndexer } from './hashing-indexer.js'
+
+class DiscardingLinkIndexer extends HashingLinkIndexer {
+  /**
+   * @template T
+   * @template {number} C
+   * @template {number} A
+   * @template {import('multiformats').Version} V
+   * @param {import('multiformats/block/interface').BlockView<T, C, A, V>} block
+   */
+  _index (block) {
+    const key = block.cid.toString()
+    if (this.idx.has(key)) {
+      return // already indexed this block
+    }
+    const targets = new Set()
+    for (const [, targetCid] of block.links()) {
+      // if we have already indexed this link, do not add as a target, we don't
+      // need to check it for the report.
+      if (this.idx.has(targetCid.toString())) {
+        continue
+      }
+      targets.add(targetCid.toString())
+      if (targetCid.multihash.code === 0x0) {
+        this._decodeAndIndexIdentityCidLink(targetCid)
+      }
+    }
+    this.idx.set(key, targets)
+  }
+}
+
+/**
+ * A linkdex reporter is an indexer that makes efficient use of memory by
+ * discarding linked CIDs that are known to already be indexed.
+ *
+ * Use this class if you only need the report and do not care about the index
+ * (`LinkIndexer.idx`) after you have finished adding blocks.
+ */
+export class Reporter {
+  #indexer
+
+  constructor () {
+    this.#indexer = new DiscardingLinkIndexer()
+  }
+
+  /**
+   * Decode the block and index any CIDs it links to.
+   * @param {import('@ipld/car/api').Block} block
+   * @param {object} [opts]
+   * @param {import('./decode.js').BlockDecoders} [opts.codecs] Bring your own codecs
+   */
+  decodeAndIndex ({ cid, bytes }, opts) {
+    return this.#indexer.decodeAndIndex({ cid, bytes }, opts)
+  }
+
+  isCompleteDag () {
+    return this.#indexer.isCompleteDag()
+  }
+
+  getDagStructureLabel () {
+    return this.#indexer.getDagStructureLabel()
+  }
+
+  report () {
+    return this.#indexer.report()
+  }
+}

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -1,0 +1,30 @@
+import test from 'ava'
+import { encode } from 'multiformats/block'
+import * as json from '@ipld/dag-json'
+import { sha256 as hasher } from 'multiformats/hashes/sha2'
+import { Reporter } from '../reporter.js'
+
+test('should report correctly when adding blocks that link to already indexed blocks', async t => {
+  const leaf0 = await encode({ value: 'leaf0', codec: json, hasher })
+  const leaf1 = await encode({ value: 'leaf1', codec: json, hasher })
+  const branch = await encode({ value: [leaf0.cid, leaf1.cid], codec: json, hasher })
+  const root = await encode({ value: { branch: branch.cid }, codec: json, hasher })
+
+  const reporter = new Reporter()
+  await reporter.decodeAndIndex(leaf0)
+  await reporter.decodeAndIndex(branch) // target (leaf0) already indexed
+  await reporter.decodeAndIndex(leaf1)
+  await reporter.decodeAndIndex(root) // target (branch) already indexed
+
+  t.is(reporter.getDagStructureLabel(), 'Complete')
+  t.is(reporter.isCompleteDag(), true)
+  t.deepEqual(reporter.report(), {
+    structure: 'Complete',
+    blocksIndexed: 4,
+    uniqueCids: 4,
+    undecodeable: 0,
+    hashPassed: 4,
+    hashFailed: 0,
+    hashUnknown: 0
+  })
+})


### PR DESCRIPTION
This PR adds a `Reporter` class, which is an indexer that makes efficient use of memory by discarding linked CIDs that are known to already be indexed.

You should only use this class if you only need the report and do not care about the index (`LinkIndexer.idx`) after you have finished adding blocks.