### PR TITLE
feat!: support index keys as CIDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
         "@web3-storage/car-block-validator": "^1.2.0",
+        "lnmap": "^1.0.1",
+        "lnset": "^1.2.0",
         "multiformats": "^11.0.2",
         "sade": "^1.8.1"
       },
@@ -2672,6 +2674,40 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lnmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lnmap/-/lnmap-1.0.1.tgz",
+      "integrity": "sha512-AmgSSYqvPHWCqMpJAZGRdkY82FXBRHwSVVf25uGCqge7xO4oabef7E4XzNUzverVhL5YobnjkgzgvidfXbfMBA==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/lnmap/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/lnset": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lnset/-/lnset-1.2.0.tgz",
+      "integrity": "sha512-Rx1y8a6N/x6D/BQIm+a44niZzxDpcbAIkBAFC2KVHjevbxyDbHUTxrltK9/5paHsQUk5/z+0FPwuzw4rAdH1vg==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/lnset/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/load-json-file": {
@@ -6245,6 +6281,36 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lnmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lnmap/-/lnmap-1.0.1.tgz",
+      "integrity": "sha512-AmgSSYqvPHWCqMpJAZGRdkY82FXBRHwSVVf25uGCqge7xO4oabef7E4XzNUzverVhL5YobnjkgzgvidfXbfMBA==",
+      "requires": {
+        "multiformats": "^12.0.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+          "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ=="
+        }
+      }
+    },
+    "lnset": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lnset/-/lnset-1.2.0.tgz",
+      "integrity": "sha512-Rx1y8a6N/x6D/BQIm+a44niZzxDpcbAIkBAFC2KVHjevbxyDbHUTxrltK9/5paHsQUk5/z+0FPwuzw4rAdH1vg==",
+      "requires": {
+        "multiformats": "^12.0.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+          "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ=="
+        }
       }
     },
     "load-json-file": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
     "@web3-storage/car-block-validator": "^1.2.0",
+    "lnmap": "^1.0.1",
+    "lnset": "^1.2.0",
     "multiformats": "^11.0.2",
     "sade": "^1.8.1"
   },


### PR DESCRIPTION
This PR adds 2 dependencies `lnmap` and `lnset` which are `Map`/`Set` implementations that allow keys to be CIDs. It means that `linkIndexer.idx` is a bit more useful. For my particular usecase I want to use the linkdex information to create content claims, which all need `Link`s. The alternative of iterating over `linkIndexer.idx` and parsing each CIDs would be a bit awkward and a perf hit.

The tests seem to run in roughly the same time and using these deps also means that in the unlikely event that two indexed blocks link to the same CID but using different IPLD codecs it'll not be indexed as 2 blocks :trollface: